### PR TITLE
Bump to go 1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module code.cloudfoundry.org/go-pubsub
 
-go 1.17
+go 1.22
 
 require github.com/poy/onpar v1.1.2


### PR DESCRIPTION
Among other things, makes golangci-lint-action work again.

Should fix https://github.com/cloudfoundry/go-pubsub/actions/runs/26306630260/job/77896927151 / https://github.com/cloudfoundry/go-pubsub/pull/44 .